### PR TITLE
This updates the instructions for ui-tests to include starting server

### DIFF
--- a/examples/tutorial_extension/ui-tests/README.md
+++ b/examples/tutorial_extension/ui-tests/README.md
@@ -37,10 +37,11 @@ jlpm playwright install
 cd ..
 ```
 
-3. Execute the [Playwright](https://playwright.dev/docs/intro) tests:
+3. Start a token-less jupyter server and execute the [Playwright](https://playwright.dev/docs/intro) tests:
 
 ```sh
 cd ./ui-tests
+jupyter lab --config jupyter_server_test_config.py &
 jlpm playwright test
 ```
 
@@ -48,6 +49,10 @@ Test results will be shown in the terminal. In case of any test failures, the te
 will be opened in your browser at the end of the tests execution; see
 [Playwright documentation](https://playwright.dev/docs/test-reporters#html-reporter)
 for configuring that behavior.
+
+A special Jupyter lab server must be running for the tests to work. The special server 
+disables a number of security features that interfere with testing. Be sure to stop the server 
+when you are done testing.
 
 ## Update the tests snapshots
 


### PR DESCRIPTION
My understanding is that galata needs a special jupyter lab server running to to function (see https://github.com/jupyterlab/jupyterlab/tree/master/galata#launch-jupyterlab).

This PR adds a step of starting the jupyter lab server with that configuration, which was already included in the repo.